### PR TITLE
Fix android image loading

### DIFF
--- a/android/src/main/java/com/rnscratchcard/RnScratchCardViewManager.kt
+++ b/android/src/main/java/com/rnscratchcard/RnScratchCardViewManager.kt
@@ -1,28 +1,20 @@
 package com.rnscratchcard
 
-import com.bumptech.glide.Glide
-import com.bumptech.glide.RequestManager
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.views.imagehelper.ImageSource
 import com.rnscratchcard.tools.px
 
 
 class RnScratchCardViewManager : SimpleViewManager<RNScratchCard>() {
-  private var requestManager: RequestManager? = null;
 
   override fun getName() = "RnScratchCardView"
 
   override fun createViewInstance(reactContext: ThemedReactContext): RNScratchCard {
-    this.requestManager = Glide.with(reactContext)
     return RNScratchCard(reactContext)
-  }
-
-  override fun onAfterUpdateTransaction(view: RNScratchCard) {
-    super.onAfterUpdateTransaction(view)
-    view.revalidate(requestManager)
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
@@ -33,7 +25,7 @@ class RnScratchCardViewManager : SimpleViewManager<RNScratchCard>() {
 
   @ReactProp(name = "image")
   fun setImage(view: RNScratchCard, source: ReadableMap) {
-    view.setSource(source)
+    view.setSource(ImageSource(view.context, source.getString("uri")))
   }
 
   @ReactProp(name = "brushWidth")

--- a/android/src/main/java/com/rnscratchcard/tools/ScratchPathManager.kt
+++ b/android/src/main/java/com/rnscratchcard/tools/ScratchPathManager.kt
@@ -73,7 +73,7 @@ class ScratchPathManager {
     paths.add(activePath)
   }
 
-  fun drawAndReset(canvas: Canvas, paint: Paint) {
+  fun drawLines(canvas: Canvas, paint: Paint) {
     for (path in paths) {
       canvas.drawPath(path, paint)
       path.reset()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1111,7 +1111,7 @@ PODS:
     - React-jsi (= 0.73.3)
     - React-logger (= 0.73.3)
     - React-perflogger (= 0.73.3)
-  - rn-scratch-card (1.2.0):
+  - rn-scratch-card (1.2.1):
     - React-Core
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
@@ -1369,7 +1369,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: aa382ce525689b88459e1181b3649220f175dc31
   React-utils: b22b4a51aa578b3aac1e7c19501c0b9ba358ed79
   ReactCommon: e708b8be8cb317b83e31c6ccfeda8bf6c0d1a2b3
-  rn-scratch-card: 1542396305fd455b7c3e7a1d0b3bb09a99e47cb4
+  rn-scratch-card: 0543176a52dce9ae779fbf0f5602552ac6ad0943
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: ff0382b894475dba0b4d2a5fda860bfee5a9afad
 


### PR DESCRIPTION
Fix #18 

Revised the Android view render logic: Essentially, the previous code modifies a single bitmap and renders it. Once the scratching is completed, we continue to use the same altered image loaded in memory. I've reverted to the logic from version 1.0.0, where, once an image is loaded, it's copied to a separate bitmap for image manipulation. Additionally, I've corrected the logic determining the scale.