### PR TITLE
Fix build error on Android

### DIFF
--- a/android/src/main/java/com/rnscratchcard/RNScratchCard.kt
+++ b/android/src/main/java/com/rnscratchcard/RNScratchCard.kt
@@ -68,7 +68,7 @@ class RNScratchCard(
       .load(source)
       .into(object : CustomTarget<Bitmap>() {
         override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-          pathStrippedImage = resource.copy(resource.config, true)
+          pathStrippedImage = resource.copy(resource.config ?: Bitmap.Config.ARGB_8888, true)
           pathStrippedImage?.let {
             pathStrippedCanvas = Canvas(it)
           }


### PR DESCRIPTION
Update RNScratchCard.kt to fix the error:

```
> Task :rn-scratch-card:compileDebugKotlin FAILED
e: file:///Users/user/Developer/project-name/node_modules/rn-scratch-card/android/src/main/java/com/rnscratchcard/RNScratchCard.kt:71:45 Argument type mismatch: actual type is 'android.graphics.Bitmap.Config?', but 'android.graphics.Bitmap.Config' was expected.


=FAILURE: Build failed with an exception.
```